### PR TITLE
Add Crypto Funding endpoints

### DIFF
--- a/lib/alpa.ex
+++ b/lib/alpa.ex
@@ -41,6 +41,7 @@ defmodule Alpa do
     * `Alpa.MarketData.Quotes` - Quote (NBBO) data
     * `Alpa.MarketData.Trades` - Trade data
     * `Alpa.MarketData.Snapshots` - Market snapshots
+    * `Alpa.Crypto.Funding` - Crypto wallets and transfers
 
   ## Configuration
 
@@ -53,6 +54,7 @@ defmodule Alpa do
   See `Alpa.Config` for details.
   """
 
+  alias Alpa.Crypto.Funding
   alias Alpa.MarketData.{Bars, Quotes, Snapshots, Trades}
   alias Alpa.Trading.{Account, Assets, CorporateActions, Market, Orders, Positions, Watchlists}
 
@@ -330,4 +332,36 @@ defmodule Alpa do
   See `Alpa.MarketData.Snapshots.get_multi/2` for details.
   """
   defdelegate snapshots(symbols, opts \\ []), to: Snapshots, as: :get_multi
+
+  # ============================================================================
+  # Crypto Funding
+  # ============================================================================
+
+  @doc """
+  List crypto wallets.
+
+  See `Alpa.Crypto.Funding.list_wallets/1` for details.
+  """
+  defdelegate crypto_wallets(opts \\ []), to: Funding, as: :list_wallets
+
+  @doc """
+  List crypto funding transfers.
+
+  See `Alpa.Crypto.Funding.list_transfers/1` for details.
+  """
+  defdelegate crypto_transfers(opts \\ []), to: Funding, as: :list_transfers
+
+  @doc """
+  Get a specific crypto transfer.
+
+  See `Alpa.Crypto.Funding.get_transfer/2` for details.
+  """
+  defdelegate crypto_transfer(id, opts \\ []), to: Funding, as: :get_transfer
+
+  @doc """
+  Request a crypto withdrawal.
+
+  See `Alpa.Crypto.Funding.create_transfer/1` for details.
+  """
+  defdelegate crypto_withdraw(params), to: Funding, as: :create_transfer
 end

--- a/lib/alpa/crypto/funding.ex
+++ b/lib/alpa/crypto/funding.ex
@@ -1,0 +1,101 @@
+defmodule Alpa.Crypto.Funding do
+  @moduledoc """
+  Crypto funding operations for the Alpaca Trading API.
+
+  Manage crypto wallets and funding transfers.
+  """
+
+  alias Alpa.Client
+  alias Alpa.Models.{CryptoWallet, CryptoTransfer}
+
+  @doc """
+  List crypto wallets.
+
+  ## Examples
+
+      iex> Alpa.Crypto.Funding.list_wallets()
+      {:ok, [%Alpa.Models.CryptoWallet{...}]}
+
+  """
+  @spec list_wallets(keyword()) :: {:ok, [CryptoWallet.t()]} | {:error, Alpa.Error.t()}
+  def list_wallets(opts \\ []) do
+    case Client.get("/v2/crypto/funding/wallets", opts) do
+      {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &CryptoWallet.from_map/1)}
+      {:ok, unexpected} -> {:error, Alpa.Error.invalid_response(unexpected)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  List crypto funding transfers.
+
+  ## Options
+
+    * `:asset` - Filter by asset symbol (e.g., "BTC")
+
+  ## Examples
+
+      iex> Alpa.Crypto.Funding.list_transfers()
+      {:ok, [%Alpa.Models.CryptoTransfer{...}]}
+
+  """
+  @spec list_transfers(keyword()) :: {:ok, [CryptoTransfer.t()]} | {:error, Alpa.Error.t()}
+  def list_transfers(opts \\ []) do
+    params =
+      opts
+      |> Keyword.take([:asset])
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
+      |> Map.new()
+
+    case Client.get("/v2/crypto/funding/transfers", Keyword.put(opts, :params, params)) do
+      {:ok, data} when is_list(data) -> {:ok, Enum.map(data, &CryptoTransfer.from_map/1)}
+      {:ok, unexpected} -> {:error, Alpa.Error.invalid_response(unexpected)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Get a specific crypto funding transfer.
+
+  ## Examples
+
+      iex> Alpa.Crypto.Funding.get_transfer("transfer-id")
+      {:ok, %Alpa.Models.CryptoTransfer{...}}
+
+  """
+  @spec get_transfer(String.t(), keyword()) :: {:ok, CryptoTransfer.t()} | {:error, Alpa.Error.t()}
+  def get_transfer(transfer_id, opts \\ []) do
+    case Client.get("/v2/crypto/funding/transfers/#{transfer_id}", opts) do
+      {:ok, data} -> {:ok, CryptoTransfer.from_map(data)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Request a crypto withdrawal.
+
+  ## Parameters
+
+    * `:amount` - Amount to withdraw (required)
+    * `:address` - Destination wallet address (required)
+    * `:symbol` - Crypto symbol, e.g. "BTC" (required)
+
+  ## Examples
+
+      iex> Alpa.Crypto.Funding.create_transfer(amount: "0.5", address: "bc1q...", symbol: "BTC")
+      {:ok, %Alpa.Models.CryptoTransfer{...}}
+
+  """
+  @spec create_transfer(keyword()) :: {:ok, CryptoTransfer.t()} | {:error, Alpa.Error.t()}
+  def create_transfer(params) when is_list(params) do
+    body =
+      params
+      |> Keyword.take([:amount, :address, :symbol])
+      |> Map.new()
+
+    case Client.post("/v2/crypto/funding/transfers", body, params) do
+      {:ok, data} -> {:ok, CryptoTransfer.from_map(data)}
+      {:error, _} = error -> error
+    end
+  end
+end

--- a/lib/alpa/models/crypto_transfer.ex
+++ b/lib/alpa/models/crypto_transfer.ex
@@ -1,0 +1,55 @@
+defmodule Alpa.Models.CryptoTransfer do
+  @moduledoc """
+  Crypto funding transfer model.
+  """
+  use TypedStruct
+
+  typedstruct do
+    field :id, String.t()
+    field :tx_hash, String.t()
+    field :direction, String.t()
+    field :status, String.t()
+    field :amount, Decimal.t()
+    field :symbol, String.t()
+    field :network_fee, Decimal.t()
+    field :fees, Decimal.t()
+    field :chain, String.t()
+    field :from_address, String.t()
+    field :to_address, String.t()
+    field :created_at, DateTime.t()
+    field :updated_at, DateTime.t()
+  end
+
+  @spec from_map(map()) :: t()
+  def from_map(data) when is_map(data) do
+    %__MODULE__{
+      id: data["id"],
+      tx_hash: data["tx_hash"],
+      direction: data["direction"],
+      status: data["status"],
+      amount: parse_decimal(data["amount"]),
+      symbol: data["symbol"],
+      network_fee: parse_decimal(data["network_fee"]),
+      fees: parse_decimal(data["fees"]),
+      chain: data["chain"],
+      from_address: data["from_address"],
+      to_address: data["to_address"],
+      created_at: parse_datetime(data["created_at"]),
+      updated_at: parse_datetime(data["updated_at"])
+    }
+  end
+
+  defp parse_decimal(nil), do: nil
+  defp parse_decimal(value) when is_binary(value), do: Decimal.new(value)
+  defp parse_decimal(value) when is_integer(value), do: Decimal.new(value)
+  defp parse_decimal(value) when is_float(value), do: Decimal.from_float(value)
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+end

--- a/lib/alpa/models/crypto_wallet.ex
+++ b/lib/alpa/models/crypto_wallet.ex
@@ -1,0 +1,36 @@
+defmodule Alpa.Models.CryptoWallet do
+  @moduledoc """
+  Crypto wallet model for funding operations.
+  """
+  use TypedStruct
+
+  typedstruct do
+    field :id, String.t()
+    field :asset_id, String.t()
+    field :symbol, String.t()
+    field :status, String.t()
+    field :address, String.t()
+    field :created_at, DateTime.t()
+  end
+
+  @spec from_map(map()) :: t()
+  def from_map(data) when is_map(data) do
+    %__MODULE__{
+      id: data["id"],
+      asset_id: data["asset_id"],
+      symbol: data["symbol"],
+      status: data["status"],
+      address: data["address"],
+      created_at: parse_datetime(data["created_at"])
+    }
+  end
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Alpa.Crypto.Funding` module with wallet and transfer operations
- Add `Alpa.Models.CryptoWallet` and `Alpa.Models.CryptoTransfer` typed models
- Add facade delegates: `Alpa.crypto_wallets/1`, `Alpa.crypto_transfers/1`, `Alpa.crypto_transfer/2`, `Alpa.crypto_withdraw/1`

Closes #6

## Endpoints covered

- `GET /v2/crypto/funding/wallets` - list wallets
- `GET /v2/crypto/funding/transfers` - list transfers
- `GET /v2/crypto/funding/transfers/{id}` - get transfer
- `POST /v2/crypto/funding/transfers` - create withdrawal

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] All 244 unit tests pass
- [ ] Integration test with paper API

🤖 Generated with [Claude Code](https://claude.com/claude-code)