### PR TITLE
Add crypto-specific market data endpoints

### DIFF
--- a/lib/alpa.ex
+++ b/lib/alpa.ex
@@ -41,6 +41,7 @@ defmodule Alpa do
     * `Alpa.MarketData.Quotes` - Quote (NBBO) data
     * `Alpa.MarketData.Trades` - Trade data
     * `Alpa.MarketData.Snapshots` - Market snapshots
+    * `Alpa.Crypto.MarketData` - Crypto market data (bars, quotes, trades, snapshots)
     * `Alpa.Crypto.Funding` - Crypto wallets and transfers
 
   ## Configuration
@@ -55,6 +56,7 @@ defmodule Alpa do
   """
 
   alias Alpa.Crypto.Funding
+  alias Alpa.Crypto.MarketData, as: CryptoMarketData
   alias Alpa.MarketData.{Bars, Quotes, Snapshots, Trades}
   alias Alpa.Trading.{Account, Assets, CorporateActions, Market, Orders, Positions, Watchlists}
 
@@ -332,6 +334,59 @@ defmodule Alpa do
   See `Alpa.MarketData.Snapshots.get_multi/2` for details.
   """
   defdelegate snapshots(symbols, opts \\ []), to: Snapshots, as: :get_multi
+
+  # ============================================================================
+  # Crypto Market Data
+  # ============================================================================
+
+  @doc """
+  Get historical crypto bars for a symbol.
+
+  See `Alpa.Crypto.MarketData.bars/2` for details.
+  """
+  defdelegate crypto_bars(symbol, opts \\ []), to: CryptoMarketData, as: :bars
+
+  @doc """
+  Get latest crypto bars for a symbol.
+
+  See `Alpa.Crypto.MarketData.latest_bars/2` for details.
+  """
+  defdelegate crypto_latest_bars(symbol, opts \\ []), to: CryptoMarketData, as: :latest_bars
+
+  @doc """
+  Get historical crypto quotes for a symbol.
+
+  See `Alpa.Crypto.MarketData.quotes/2` for details.
+  """
+  defdelegate crypto_quotes(symbol, opts \\ []), to: CryptoMarketData, as: :quotes
+
+  @doc """
+  Get latest crypto quotes for a symbol.
+
+  See `Alpa.Crypto.MarketData.latest_quotes/2` for details.
+  """
+  defdelegate crypto_latest_quotes(symbol, opts \\ []), to: CryptoMarketData, as: :latest_quotes
+
+  @doc """
+  Get historical crypto trades for a symbol.
+
+  See `Alpa.Crypto.MarketData.trades/2` for details.
+  """
+  defdelegate crypto_trades(symbol, opts \\ []), to: CryptoMarketData, as: :trades
+
+  @doc """
+  Get latest crypto trades for a symbol.
+
+  See `Alpa.Crypto.MarketData.latest_trades/2` for details.
+  """
+  defdelegate crypto_latest_trades(symbol, opts \\ []), to: CryptoMarketData, as: :latest_trades
+
+  @doc """
+  Get crypto snapshots for one or more symbols.
+
+  See `Alpa.Crypto.MarketData.snapshots/2` for details.
+  """
+  defdelegate crypto_snapshots(symbols, opts \\ []), to: CryptoMarketData, as: :snapshots
 
   # ============================================================================
   # Crypto Funding

--- a/lib/alpa/crypto/market_data.ex
+++ b/lib/alpa/crypto/market_data.ex
@@ -13,11 +13,18 @@ defmodule Alpa.Crypto.MarketData do
   """
 
   alias Alpa.Client
+  alias Alpa.Models.{Bar, Quote, Trade, Snapshot}
 
   @default_loc "us"
 
+  # ============================================================================
+  # Bars
+  # ============================================================================
+
   @doc """
   Get historical bars for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Bar` structs.
 
   ## Required Parameters
 
@@ -31,6 +38,234 @@ defmodule Alpa.Crypto.MarketData do
     * `:limit` - Max bars to return (default 1000, max 10000)
     * `:page_token` - Pagination token
     * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.bars("BTC/USD", timeframe: "1Day", limit: 10)
+      {:ok, [%Alpa.Models.Bar{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec bars(String.t(), keyword()) :: {:ok, [Bar.t()]} | {:error, Alpa.Error.t()}
+  def bars(symbol, opts \\ []) do
+    case get_bars(symbol, opts) do
+      {:ok, data} -> {:ok, parse_bars(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Get latest bars for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Bar` structs.
+
+  ## Required Parameters
+
+    * `symbol` - Crypto symbol (e.g., "BTC/USD")
+
+  ## Options
+
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.latest_bars("BTC/USD")
+      {:ok, [%Alpa.Models.Bar{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec latest_bars(String.t(), keyword()) :: {:ok, [Bar.t()]} | {:error, Alpa.Error.t()}
+  def latest_bars(symbol, opts \\ []) do
+    {loc, opts} = Keyword.pop(opts, :loc, @default_loc)
+
+    params = %{symbols: symbol}
+
+    case Client.get_data(
+           "/v1beta3/crypto/#{loc}/latest/bars",
+           Keyword.put(opts, :params, params)
+         ) do
+      {:ok, data} -> {:ok, parse_bars(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  # ============================================================================
+  # Quotes
+  # ============================================================================
+
+  @doc """
+  Get historical quotes for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Quote` structs.
+
+  ## Required Parameters
+
+    * `symbol` - Crypto symbol (e.g., "BTC/USD")
+
+  ## Options
+
+    * `:start` - Start time (DateTime or ISO 8601 string)
+    * `:end` - End time (DateTime or ISO 8601 string)
+    * `:limit` - Max quotes to return (default 1000, max 10000)
+    * `:page_token` - Pagination token
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.quotes("BTC/USD", limit: 10)
+      {:ok, [%Alpa.Models.Quote{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec quotes(String.t(), keyword()) :: {:ok, [Quote.t()]} | {:error, Alpa.Error.t()}
+  def quotes(symbol, opts \\ []) do
+    case get_quotes(symbol, opts) do
+      {:ok, data} -> {:ok, parse_quotes(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Get latest quotes for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Quote` structs.
+
+  ## Required Parameters
+
+    * `symbol` - Crypto symbol (e.g., "BTC/USD")
+
+  ## Options
+
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.latest_quotes("BTC/USD")
+      {:ok, [%Alpa.Models.Quote{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec latest_quotes(String.t(), keyword()) :: {:ok, [Quote.t()]} | {:error, Alpa.Error.t()}
+  def latest_quotes(symbol, opts \\ []) do
+    {loc, opts} = Keyword.pop(opts, :loc, @default_loc)
+
+    params = %{symbols: symbol}
+
+    case Client.get_data(
+           "/v1beta3/crypto/#{loc}/latest/quotes",
+           Keyword.put(opts, :params, params)
+         ) do
+      {:ok, data} -> {:ok, parse_quotes(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  # ============================================================================
+  # Trades
+  # ============================================================================
+
+  @doc """
+  Get historical trades for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Trade` structs.
+
+  ## Required Parameters
+
+    * `symbol` - Crypto symbol (e.g., "BTC/USD")
+
+  ## Options
+
+    * `:start` - Start time (DateTime or ISO 8601 string)
+    * `:end` - End time (DateTime or ISO 8601 string)
+    * `:limit` - Max trades to return (default 1000, max 10000)
+    * `:page_token` - Pagination token
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.trades("BTC/USD", limit: 10)
+      {:ok, [%Alpa.Models.Trade{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec trades(String.t(), keyword()) :: {:ok, [Trade.t()]} | {:error, Alpa.Error.t()}
+  def trades(symbol, opts \\ []) do
+    case get_trades(symbol, opts) do
+      {:ok, data} -> {:ok, parse_trades(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Get latest trades for a crypto symbol.
+
+  Returns parsed `Alpa.Models.Trade` structs.
+
+  ## Required Parameters
+
+    * `symbol` - Crypto symbol (e.g., "BTC/USD")
+
+  ## Options
+
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.latest_trades("BTC/USD")
+      {:ok, [%Alpa.Models.Trade{symbol: "BTC/USD", ...}]}
+
+  """
+  @spec latest_trades(String.t(), keyword()) :: {:ok, [Trade.t()]} | {:error, Alpa.Error.t()}
+  def latest_trades(symbol, opts \\ []) do
+    {loc, opts} = Keyword.pop(opts, :loc, @default_loc)
+
+    params = %{symbols: symbol}
+
+    case Client.get_data(
+           "/v1beta3/crypto/#{loc}/latest/trades",
+           Keyword.put(opts, :params, params)
+         ) do
+      {:ok, data} -> {:ok, parse_trades(data, symbol)}
+      {:error, _} = error -> error
+    end
+  end
+
+  # ============================================================================
+  # Snapshots
+  # ============================================================================
+
+  @doc """
+  Get snapshots for one or more crypto symbols.
+
+  Returns parsed `Alpa.Models.Snapshot` structs.
+
+  ## Required Parameters
+
+    * `symbols` - A symbol string or list of symbols (e.g., "BTC/USD" or ["BTC/USD", "ETH/USD"])
+
+  ## Options
+
+    * `:loc` - Location (default: "us")
+
+  ## Examples
+
+      iex> Alpa.Crypto.MarketData.snapshots("BTC/USD")
+      {:ok, %{"BTC/USD" => %Alpa.Models.Snapshot{...}}}
+
+      iex> Alpa.Crypto.MarketData.snapshots(["BTC/USD", "ETH/USD"])
+      {:ok, %{"BTC/USD" => %Alpa.Models.Snapshot{...}, "ETH/USD" => %Alpa.Models.Snapshot{...}}}
+
+  """
+  @spec snapshots(String.t() | [String.t()], keyword()) ::
+          {:ok, %{String.t() => Snapshot.t()}} | {:error, Alpa.Error.t()}
+  def snapshots(symbols, opts \\ []) do
+    case get_snapshots(symbols, opts) do
+      {:ok, data} -> {:ok, parse_snapshots(data)}
+      {:error, _} = error -> error
+    end
+  end
+
+  # ============================================================================
+  # Raw API functions (return unparsed maps)
+  # ============================================================================
+
+  @doc """
+  Get historical bars for a crypto symbol (raw response).
 
   ## Examples
 
@@ -54,19 +289,7 @@ defmodule Alpa.Crypto.MarketData do
   end
 
   @doc """
-  Get historical quotes for a crypto symbol.
-
-  ## Required Parameters
-
-    * `symbol` - Crypto symbol (e.g., "BTC/USD")
-
-  ## Options
-
-    * `:start` - Start time (DateTime or ISO 8601 string)
-    * `:end` - End time (DateTime or ISO 8601 string)
-    * `:limit` - Max quotes to return (default 1000, max 10000)
-    * `:page_token` - Pagination token
-    * `:loc` - Location (default: "us")
+  Get historical quotes for a crypto symbol (raw response).
 
   ## Examples
 
@@ -90,19 +313,7 @@ defmodule Alpa.Crypto.MarketData do
   end
 
   @doc """
-  Get historical trades for a crypto symbol.
-
-  ## Required Parameters
-
-    * `symbol` - Crypto symbol (e.g., "BTC/USD")
-
-  ## Options
-
-    * `:start` - Start time (DateTime or ISO 8601 string)
-    * `:end` - End time (DateTime or ISO 8601 string)
-    * `:limit` - Max trades to return (default 1000, max 10000)
-    * `:page_token` - Pagination token
-    * `:loc` - Location (default: "us")
+  Get historical trades for a crypto symbol (raw response).
 
   ## Examples
 
@@ -126,22 +337,11 @@ defmodule Alpa.Crypto.MarketData do
   end
 
   @doc """
-  Get snapshots for one or more crypto symbols.
-
-  ## Required Parameters
-
-    * `symbols` - A symbol string or list of symbols (e.g., "BTC/USD" or ["BTC/USD", "ETH/USD"])
-
-  ## Options
-
-    * `:loc` - Location (default: "us")
+  Get snapshots for one or more crypto symbols (raw response).
 
   ## Examples
 
       iex> Alpa.Crypto.MarketData.get_snapshots("BTC/USD")
-      {:ok, %{"snapshots" => ...}}
-
-      iex> Alpa.Crypto.MarketData.get_snapshots(["BTC/USD", "ETH/USD"])
       {:ok, %{"snapshots" => ...}}
 
   """
@@ -201,7 +401,9 @@ defmodule Alpa.Crypto.MarketData do
     )
   end
 
+  # ============================================================================
   # Private helpers
+  # ============================================================================
 
   defp build_params(opts, keys) do
     opts
@@ -214,4 +416,43 @@ defmodule Alpa.Crypto.MarketData do
     |> Enum.reject(fn {_, v} -> is_nil(v) end)
     |> Map.new()
   end
+
+  defp parse_bars(%{"bars" => bars}, symbol) when is_map(bars) do
+    case Map.get(bars, symbol) do
+      nil -> []
+      bar_list when is_list(bar_list) -> Enum.map(bar_list, &Bar.from_map(&1, symbol))
+    end
+  end
+
+  defp parse_bars(%{"bars" => nil}, _symbol), do: []
+  defp parse_bars(_, _symbol), do: []
+
+  defp parse_quotes(%{"quotes" => quotes}, symbol) when is_map(quotes) do
+    case Map.get(quotes, symbol) do
+      nil -> []
+      quote_list when is_list(quote_list) -> Enum.map(quote_list, &Quote.from_map(&1, symbol))
+    end
+  end
+
+  defp parse_quotes(%{"quotes" => nil}, _symbol), do: []
+  defp parse_quotes(_, _symbol), do: []
+
+  defp parse_trades(%{"trades" => trades}, symbol) when is_map(trades) do
+    case Map.get(trades, symbol) do
+      nil -> []
+      trade_list when is_list(trade_list) -> Enum.map(trade_list, &Trade.from_map(&1, symbol))
+    end
+  end
+
+  defp parse_trades(%{"trades" => nil}, _symbol), do: []
+  defp parse_trades(_, _symbol), do: []
+
+  defp parse_snapshots(%{"snapshots" => snapshots}) when is_map(snapshots) do
+    Map.new(snapshots, fn {symbol, data} ->
+      {symbol, Snapshot.from_map(data, symbol)}
+    end)
+  end
+
+  defp parse_snapshots(%{"snapshots" => nil}), do: %{}
+  defp parse_snapshots(_), do: %{}
 end

--- a/test/alpa/crypto/market_data_test.exs
+++ b/test/alpa/crypto/market_data_test.exs
@@ -1,0 +1,108 @@
+defmodule Alpa.Crypto.MarketDataTest do
+  use ExUnit.Case, async: true
+
+  alias Alpa.Crypto.MarketData
+  alias Alpa.Error
+
+  describe "bars/2" do
+    test "requires credentials" do
+      result = MarketData.bars("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "latest_bars/2" do
+    test "requires credentials" do
+      result = MarketData.latest_bars("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "quotes/2" do
+    test "requires credentials" do
+      result = MarketData.quotes("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "latest_quotes/2" do
+    test "requires credentials" do
+      result = MarketData.latest_quotes("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "trades/2" do
+    test "requires credentials" do
+      result = MarketData.trades("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "latest_trades/2" do
+    test "requires credentials" do
+      result = MarketData.latest_trades("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "snapshots/2" do
+    test "requires credentials with single symbol" do
+      result = MarketData.snapshots("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+
+    test "requires credentials with multiple symbols" do
+      result = MarketData.snapshots(["BTC/USD", "ETH/USD"], api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "get_bars/2" do
+    test "requires credentials" do
+      result = MarketData.get_bars("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "get_quotes/2" do
+    test "requires credentials" do
+      result = MarketData.get_quotes("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "get_trades/2" do
+    test "requires credentials" do
+      result = MarketData.get_trades("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "get_snapshots/2" do
+    test "requires credentials" do
+      result = MarketData.get_snapshots("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+
+  describe "get_orderbook/2" do
+    test "requires credentials" do
+      result = MarketData.get_orderbook("BTC/USD", api_key: nil, api_secret: nil)
+
+      assert {:error, %Error{type: :missing_credentials}} = result
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extend `Alpa.Crypto.MarketData` with typed functions (`bars/2`, `latest_bars/2`, `quotes/2`, `latest_quotes/2`, `trades/2`, `latest_trades/2`, `snapshots/2`) that return parsed `Bar`, `Quote`, `Trade`, and `Snapshot` model structs
- Add facade delegates in the top-level `Alpa` module (e.g. `crypto_bars/2`, `crypto_quotes/2`, etc.)
- Add `Alpa.Crypto.MarketData` to the module listing in `Alpa` moduledoc
- Add comprehensive tests following the existing credential-check pattern

## Test plan
- [x] `mix compile` succeeds with no warnings
- [x] `mix test` passes all 257 tests (0 failures)
- [ ] Verify crypto bars endpoint returns parsed `Alpa.Models.Bar` structs
- [ ] Verify crypto quotes endpoint returns parsed `Alpa.Models.Quote` structs
- [ ] Verify crypto trades endpoint returns parsed `Alpa.Models.Trade` structs
- [ ] Verify crypto snapshots endpoint returns parsed `Alpa.Models.Snapshot` structs

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)