### PR TITLE
Allow binary frames

### DIFF
--- a/lib/alpa/stream/trade_updates.ex
+++ b/lib/alpa/stream/trade_updates.ex
@@ -180,6 +180,9 @@ defmodule Alpa.Stream.TradeUpdates do
   end
 
   @impl WebSockex
+  def handle_frame({:binary, msg}, state), do: handle_frame({:text, msg}, state)
+
+  @impl WebSockex
   def handle_frame({:text, msg}, state) do
     case Jason.decode(msg) do
       {:ok, %{"stream" => "authorization", "data" => %{"status" => "authorized"}}} ->


### PR DESCRIPTION
Alapca over websocket sends some messages as binary frames when using paper trading:

https://docs.alpaca.markets/us/docs/websocket-streaming

specifically for the `trade_updates`

```
Note:

The trade_updates stream coming from wss://paper-api.alpaca.markets/stream 
uses binary frames, which differs from the text frames that comes from the 
wss://data.alpaca.markets/stream stream.
```

eg:

```
[debug] [TradeUpdates] Received frame: {:binary, "{\"stream\":\"authorization\",\"data\":{\"action\":\"authenticate\",\"status\":\"authorized\"}}"}
```

This change allows the module to handle frames in that format too, simply handing off to the existing function for decoding